### PR TITLE
Custom Weapon Support

### DIFF
--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -218,7 +218,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
             }
 
             // Handle weapon/basic
-            if ((type === 'weapon' || type === 'basic') && system.damage) {
+            if ((type === 'weapon' || type === 'basic' || type === 'customWeapon') && system.damage) {
                 const accuracy = system.accuracy?.value
                 if (accuracy !== undefined) {
                     const primary = system.attributes?.primary?.value || 'MIG'

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -63,7 +63,6 @@ export const GROUP = {
     equipped: { id: 'equipped', name: 'tokenActionHud.fu.equipped.label', type: 'system' },
     basic: { id: 'basic', name: 'TYPES.Item.basic', type: 'system' },
     weapon: { id: 'weapon', name: 'TYPES.Item.weapon', type: 'system' },
-    customWeapon: { id: 'customWeapon', name: 'TYPES.Item.weapon', type: 'system' },
     shield: { id: 'shield', name: 'TYPES.Item.shield', type: 'system' },
     armor: { id: 'armor', name: 'TYPES.Item.armor', type: 'system' },
     accessory: { id: 'accessory', name: 'TYPES.Item.accessory', type: 'system' },
@@ -113,7 +112,7 @@ export const GROUP = {
 export const ITEM_TYPE = {
     basic: { groupId: 'basic' },
     weapon: { groupId: 'weapon' },
-    customWeapon: { groupId: 'customWeapon' },
+    customWeapon: { groupId: 'weapon' },
     shield: { groupId: 'shield' },
     armor: { groupId: 'armor' },
     accessory: { groupId: 'accessory' },

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -63,6 +63,7 @@ export const GROUP = {
     equipped: { id: 'equipped', name: 'tokenActionHud.fu.equipped.label', type: 'system' },
     basic: { id: 'basic', name: 'TYPES.Item.basic', type: 'system' },
     weapon: { id: 'weapon', name: 'TYPES.Item.weapon', type: 'system' },
+    customWeapon: { id: 'customWeapon', name: 'TYPES.Item.weapon', type: 'system' },
     shield: { id: 'shield', name: 'TYPES.Item.shield', type: 'system' },
     armor: { id: 'armor', name: 'TYPES.Item.armor', type: 'system' },
     accessory: { id: 'accessory', name: 'TYPES.Item.accessory', type: 'system' },
@@ -112,6 +113,7 @@ export const GROUP = {
 export const ITEM_TYPE = {
     basic: { groupId: 'basic' },
     weapon: { groupId: 'weapon' },
+    customWeapon: { groupId: 'customWeapon' },
     shield: { groupId: 'shield' },
     armor: { groupId: 'armor' },
     accessory: { groupId: 'accessory' },

--- a/scripts/defaults.js
+++ b/scripts/defaults.js
@@ -23,7 +23,8 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 name: coreModule.api.Utils.i18n('Attack'),
                 groups: [
                     { ...groups.basic, nestId: 'attack_basic' },
-                    { ...groups.weapon, nestId: 'attack_weapon' }
+                    { ...groups.weapon, nestId: 'attack_weapon' },
+                    { ...groups.customWeapon, nestId: 'attack_customWeapon' }
                 ]
             },
             {

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -14,7 +14,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          */
         async handleActionClick (event, encodedValue) {
             const [actionTypeId, actionId] = encodedValue.split('|')
-            const isShift = this.isShift
+            const isShift = this.isShift;
 
             const renderable = ['item']
 
@@ -163,7 +163,13 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 shift: event.shiftKey,
                 ctrl: event.ctrlKey
             }
-            item.roll(modifiers)
+            
+            if (item.type === "customWeapon" && item.system.isTransforming && modifiers.ctrl) {
+                console.log("Changing form");
+                item.system.switchForm();
+            } else {
+                item.roll(modifiers)
+            }
         }
 
         /**


### PR DESCRIPTION
Adds support for the `customWeapon` item type, including if they're transforming

| <img width="500" alt="image" src="https://github.com/user-attachments/assets/36513633-e587-419b-bf46-9fce2b298cd2" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/c7572391-9bbc-40f6-9c2b-be509055d18a" /> |
|-|-|

