### PR TITLE
Token Action HUD Core 2.1

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -15,7 +15,7 @@ export const CORE_MODULE = {
 /**
  * Core module version required by the system module
  */
-export const REQUIRED_CORE_MODULE_VERSION = '2.0'
+export const REQUIRED_CORE_MODULE_VERSION = '2.1'
 
 /**
  * Action types


### PR DESCRIPTION
This PR bumps `REQUIRED_CORE_MODULE_VERSION` to 2.1
No changes are needed to maintain compatibility.